### PR TITLE
server: Fix port to 443 if ssl enabled or custom string

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -564,7 +564,7 @@ class WebThingServer {
   constructor(things, port, sslOptions) {
     this.things = things;
     this.name = things.getName();
-    this.port = port || 80;
+    this.port = Number(port) || (sslOptions ? 443 : 80);
     this.ipPromise = utils.getIP().then((ip) => {
       this.ip = ip;
 


### PR DESCRIPTION
Convert port to number if typed as string

This is helpful for real apps

Change-Id: I368639b3ba573249c64bb992439fbe010a049945
Signed-off-by: Philippe Coval <p.coval@samsung.com>