### PR TITLE
example: Add simplest actuator example

### DIFF
--- a/example/simplest-thing.js
+++ b/example/simplest-thing.js
@@ -1,0 +1,55 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: MPL-2.0
+/**
+ *
+ * Copyright 2018-present Samsung Electronics France SAS, and other contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+const {
+  Action,
+  Event,
+  Property,
+  SingleThing,
+  Thing,
+  Value,
+  WebThingServer,
+} = require('../index');
+
+function makeThing() {
+  const thing = new Thing('ActuatorExample', 'onOffSwitch', 'An actuator example that just log');
+
+  const value = new Value(true, function(update) {
+    console.log("change: " + update);
+  });
+  thing.addProperty(
+    new Property(thing,
+                 'on',
+                 value,
+                 {type: 'boolean',
+                  description: 'Whether the output is changed'}));
+  return thing;
+}
+
+function main() {
+  const port = process.argv[2] ? Number(process.argv[2]) : 8888;
+  const url = `http://localhost:${port}/properties/on`;
+  console.log(`Usage:\n
+${process.argv[0]} ${process.argv[1]} [port]
+
+Try:
+curl -X PUT -H 'Content-Type: application/json' --data '{"on": true }' ${url}
+`);
+
+  const thing = makeThing();
+  const server = new WebThingServer(new SingleThing(thing), port);
+  process.on('SIGINT', () => {
+    server.stop();
+    process.exit();
+  });
+  server.start();
+}
+
+main();

--- a/example/simplest-thing.js
+++ b/example/simplest-thing.js
@@ -9,8 +9,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
  */
 const {
-  Action,
-  Event,
   Property,
   SingleThing,
   Thing,
@@ -19,23 +17,23 @@ const {
 } = require('../index');
 
 function makeThing() {
-  const thing = new Thing('ActuatorExample', 'onOffSwitch', 'An actuator example that just log');
+  const thing = new Thing('ActuatorExample',
+                          'onOffSwitch',
+                          'An actuator example that just log');
 
-  const value = new Value(true, function(update) {
-    console.log("change: " + update);
-  });
   thing.addProperty(
     new Property(thing,
                  'on',
-                 value,
+                 new Value(true, (update) => console.log(`change: ${update}`)),
                  {type: 'boolean',
                   description: 'Whether the output is changed'}));
   return thing;
 }
 
-function main() {
+function runServer() {
   const port = process.argv[2] ? Number(process.argv[2]) : 8888;
   const url = `http://localhost:${port}/properties/on`;
+
   console.log(`Usage:\n
 ${process.argv[0]} ${process.argv[1]} [port]
 
@@ -52,4 +50,4 @@ curl -X PUT -H 'Content-Type: application/json' --data '{"on": true }' ${url}
   server.start();
 }
 
-main();
+runServer();


### PR DESCRIPTION
It can used using:

curl -X PUT -H 'Content-Type: application/json' --data '{"on": true }' \
  http://localhost:8888/properties/on

This base was helpful to port to alternate runtimes (ie: IoT.js)

More details and demo video at:

https://s-opensource.org/webthing-iotjs/

Change-Id: Ie126c5621b18afd0094ee21b06501b22a726974a
Origin: https://github.com/tizenteam/webthing-node
Signed-off-by: Philippe Coval <p.coval@samsung.com>