### PR TITLE
Rename index.js to webthing-node.js for import

### DIFF
--- a/example/multiple-things.js
+++ b/example/multiple-things.js
@@ -6,7 +6,7 @@ const {
   Thing,
   Value,
   WebThingServer,
-} = require('../index');
+} = require('webthing');
 const uuidv4 = require('uuid/v4');
 
 class OverheatedEvent extends Event {

--- a/example/simplest-thing.js
+++ b/example/simplest-thing.js
@@ -14,7 +14,7 @@ const {
   Thing,
   Value,
   WebThingServer,
-} = require('../index');
+} = require('webthing');
 
 function makeThing() {
   const thing = new Thing('ActuatorExample',

--- a/example/single-thing.js
+++ b/example/single-thing.js
@@ -6,7 +6,7 @@ const {
   Thing,
   Value,
   WebThingServer,
-} = require('../index');
+} = require('webthing');
 const uuidv4 = require('uuid/v4');
 
 class OverheatedEvent extends Event {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "webthing",
   "version": "0.7.0",
   "description": "HTTP Web Thing implementation",
-  "main": "index.js",
+  "main": "webthing.js",
   "scripts": {
     "lint": "eslint .",
-    "start": "node example/multiple-things",
+    "start": "NODE_PATH=. node example/multiple-things",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/travis.sh
+++ b/travis.sh
@@ -7,6 +7,7 @@ npm run lint
 git clone https://github.com/mozilla-iot/webthing-tester
 pip3 install --user -r webthing-tester/requirements.txt
 
+export NODE_PATH=.
 # build and test the single-thing example
 node example/single-thing.js &
 EXAMPLE_PID=$!

--- a/webthing.js
+++ b/webthing.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   Action: require('./lib/action'),
   Event: require('./lib/event'),


### PR DESCRIPTION
Now examples can be run from source directory,

    NODE_PATH=. node example/simplest-thing

Or script can run from out of tree, when installed using NPM

    MODE_PATH=node_modules node node_modules/example/simplest-thing

Then you can build a systemd service,
if you want thing to be active at boot,
some Hints at:
https://s-opensource.org/2018/06/21/webthing-iotjs/

To check module with multiple-things example, just use:

   npm start

Change-Id: I32c4c08b9e15c3e25103dc78f90a901f40080fbb
Signed-off-by: Philippe Coval <p.coval@samsung.com>