### PR TITLE
server: Stop mdns only if already started

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -693,7 +693,9 @@ class WebThingServer {
    * Stop listening.
    */
   stop() {
-    this.mdns.stop();
+    if (this.mdns) {
+      this.mdns.stop();
+    }
     this.server.close();
   }
 }


### PR DESCRIPTION
This issue was observed while playing with GPIO

Change-Id: Ib4e2df5f98060851c755f4f6fc9c036b0895cf5a
Signed-off-by: Philippe Coval <p.coval@samsung.com>