### PR TITLE
build: Support docker for test or demo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+.git/
+#.gitignore contents:
+*~
+*.swp
+*.tgz
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+#!/bin/echo docker build . -f
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MPL-2.0
+#{
+# Copyright: 2018-present Samsung Electronics France SAS, and other contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+#}
+
+FROM node:8-stretch
+MAINTAINER Philippe Coval (p.coval@samsung.com)
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL en_US.UTF-8
+ENV LANG ${LC_ALL}
+
+ADD . /usr/local/${project}/${project}
+WORKDIR /usr/local/${project}/${project}
+RUN echo "#log: ${project}: Preparing sources" \
+  && set -x \
+  && which npm \
+  && npm --version \
+  && npm install \
+  && npm run test || echo "TODO: check package.json" \
+  && sync
+
+EXPOSE 8888
+WORKDIR /usr/local/${project}/${project}
+CMD [ "/usr/local/bin/npm" "run" "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: MPL-2.0 
+#{
+#  Copyright: 2018-present Samsung Electronics Co., Ltd. and other contributors
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#}
+
+version: "2"
+
+services:
+  web:
+    build: .
+    command: /usr/local/bin/npm run start
+    volumes:
+      - /usr/local/webthing-node/webthing-node
+    ports:
+      - "8888:8888"


### PR DESCRIPTION
Usage is straightforward just run:

    docker-compose up
    # Creating webthingnode_web_1 ...
    # (...)
    # web_1  | > node example/multiple-things
    # web_1  | setting new humidity level: 0.7381314277767015
    # web_1  | setting new humidity level: 7.724829674410808

On benefit of having docker files in sources,
is that project can be built on reference OS,
and be deployed on any as long as docker is supported.

This could be good also for tracking regressions (using git-bisect ?).

Origin: https://github.com/rzr/webthing-iotjs
Change-Id: I2924036381d441761df5da50cf089020c3b1f501
Signed-off-by: Philippe Coval <p.coval@samsung.com>