### PR TITLE
example: platform: Add GpioProperty

### DIFF
--- a/example/platform/board/artik530.js
+++ b/example/platform/board/artik530.js
@@ -1,0 +1,61 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ *
+ * Copyright 2018-present Samsung Electronics France SAS, and other contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+const {
+  Thing,
+} = require('webthing');
+
+const GpioProperty = require('../gpio/gpio-property');
+
+class ARTIK530Thing extends Thing {
+  constructor(name, type, description) {
+    super(name || 'ARTIK530',
+          type || [],
+          description || 'A web connected ARTIK530 or ARTIK720');
+    const _this = this;
+    this.gpioProperties = [
+      new GpioProperty(this, 'RedLED', false,
+                       {description:
+                             'Red LED on interposer board (on GPIO28)'},
+                       {direction: 'out', pin: 28}),
+      new GpioProperty(this, 'BlueLED', false,
+                       {description:
+                             'Blue LED on interposer board (on GPIO38)'},
+                       {direction: 'out', pin: 38}),
+      new GpioProperty(this, 'Up', false,
+                       {description:
+                             'SW403 Button: Nearest board edge,\
+ next to red LED (on GPIO30)'},
+                       {direction: 'in', pin: 30}),
+      new GpioProperty(this, 'Down', false,
+                       {description:
+                             'SW404 Button: Next to blue LED (on GPIO32)'},
+                       {direction: 'in', pin: 32}),
+    ];
+    this.gpioProperties.forEach((property) => {
+      _this.addProperty(property);
+    });
+  }
+
+  close() {
+    this.gpioProperties.forEach((property) => {
+      property.close && property.close();
+    });
+  }
+}
+
+module.exports = () => {
+  if (!module.exports.instance) {
+    module.exports.instance = new ARTIK530Thing();
+  }
+  return module.exports.instance;
+};

--- a/example/platform/gpio/gpio-property.js
+++ b/example/platform/gpio/gpio-property.js
@@ -1,0 +1,120 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ *
+ * Copyright 2018-present Samsung Electronics France SAS, and other contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+const console = require('console');
+
+// Disable logs here by editing to '!console.log'
+const log = console.log || function() {};
+
+const {
+  Property,
+  Value,
+} = require('webthing');
+
+const gpio = require('gpio');
+
+class GpioOutProperty extends Property {
+  constructor(thing, name, value, metadata, config) {
+    const valueObject = new Value(value, (value) => {
+      this.handleValueChanged && this.handleValueChanged(value);
+    });
+    super(thing, name, valueObject,
+          {
+            '@type': 'OnOffProperty',
+            label: (metadata && metadata.label) || `On/Off: ${name}`,
+            type: 'boolean',
+            description: (metadata && metadata.description) ||
+              (`GPIO Actuator on pin=${config.pin}`),
+          });
+    const _this = this;
+    this.config = config;
+
+    this.port = gpio.export(config.pin,
+                            {direction: 'out',
+                             ready: () => {
+                               log(`log: GPIO: ${_this.getName()}: open:`);
+                               _this.handleValueChanged = (value) => {
+                                 try {
+                                   log(`log: GPIO: ${_this.getName()}: \
+writing: ${value}`);
+                                   _this.port.set(value);
+                                 } catch (err) {
+                                   console.error(`error: GPIO: 
+${_this.getName()}: Fail to write: ${err}`);
+                                   return err;
+                                 }
+                               };
+                             }});
+  }
+
+  close() {
+    const _this = this;
+    try {
+      this.port && this.port.unexport(this.config.pin);
+    } catch (err) {
+      console.error(`error: GPIO: ${this.getName()}: Fail to close: ${err}`);
+      return err;
+    }
+    log(`log: GPIO: ${_this.getName()}: close:`);
+  }
+}
+
+
+class GpioInProperty extends Property {
+  constructor(thing, name, value, metadata, config) {
+    super(thing, name, new Value(Boolean(value)),
+          {
+            '@type': 'BooleanProperty',
+            label: (metadata && metadata.label) || `On/Off: ${name}`,
+            type: 'boolean',
+            description:
+            (metadata && metadata.description) ||
+              (`GPIO Sensor on pin=${config.pin}`),
+          });
+    const _this = this;
+    this.config = config;
+    const callback = () => {
+      log(`log: GPIO: ${_this.getName()}: open:`);
+      _this.port.on('change', (value) => {
+        value = Boolean(value);
+        log(`log: GPIO: ${_this.getName()}: change: ${value}`);
+        _this.value.notifyOfExternalUpdate(value);
+      });
+    };
+    this.port = gpio.export(config.pin,
+                            {direction: 'in', ready: callback});
+  }
+
+  close() {
+    const _this = this;
+    try {
+      this.inverval && clearInterval(this.inverval);
+      this.port && this.port.unexport(this.config.pin);
+    } catch (err) {
+      console.error(`error: GPIO: ${this.getName()} close:${err}`);
+      return err;
+    }
+    log(`log: GPIO: ${_this.getName()}: close:`);
+  }
+}
+
+
+function GpioProperty(thing, name, value, metadata, config) {
+  if (config.direction === 'out') {
+    return new GpioOutProperty(thing, name, value, metadata, config);
+  } else if (config.direction === 'in') {
+    return new GpioInProperty(thing, name, value, metadata, config);
+  }
+  throw 'error: Invalid param';
+}
+
+module.exports = GpioProperty;

--- a/example/platform/index.js
+++ b/example/platform/index.js
@@ -1,0 +1,52 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ *
+ * Copyright 2018-present Samsung Electronics France SAS, and other contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+const console = require('console');
+
+// TODO: disable logs here by editing to '!console.log'
+const log = console.log || function() {};
+
+const {
+  SingleThing,
+  WebThingServer,
+} = require('webthing');
+
+// Update with different board here if needed
+let board = 'artik530';
+if (process.argv.length > 2) {
+  board = String(process.argv[2]);
+}
+
+log(`log: board: ${board}: Loading`);
+const BoardThing = require(`./board/${board}`);
+
+function runServer() {
+  const port = process.argv[3] ? Number(process.argv[3]) : 8888;
+  const url = `http://localhost:${port}`;
+
+  log(`Usage:\n\
+${process.argv[0]} ${process.argv[1]} [board] [port]\n\
+Try:\ncurl -H "Accept: application/json" ${url}\
+\n`);
+  const thing = new BoardThing();
+  const server = new WebThingServer(new SingleThing(thing), port);
+  process.on('SIGINT', () => {
+    server.stop();
+    thing && thing.close();
+    log(`log: board: ${board}: Stopped`);
+    process.exit();
+  });
+  server.start();
+  log(`log: board: ${board}: Started`);
+}
+
+runServer();


### PR DESCRIPTION
Based on sysfs GPIO driver

It is located in $module/*.js
to support serverals drivers (wiring, etc)

Change-Id: Ib393bb3f431f7b5bd3a3ce48797cd5ee08e9af49
Origin: https://github.com/rzr/webthing-iotjs
Signed-off-by: Philippe Coval <p.coval@samsung.com>