### PR TITLE
example: platform: Fix artik530 export

### DIFF
--- a/example/platform/board/artik530.js
+++ b/example/platform/board/artik530.js
@@ -53,7 +53,7 @@ class ARTIK530Thing extends Thing {
   }
 }
 
-module.exports = () => {
+module.exports = function() {
   if (!module.exports.instance) {
     module.exports.instance = new ARTIK530Thing();
   }


### PR DESCRIPTION
Mistake BoardThing should be a "constructor" for new

Maybe squashed into:

eff5122cd83fcd4048c6a3247801ba6702d09e0f

Relate-to: https://github.com/mozilla-iot/webthing-node/pull/30
Change-Id: I15d8dfe936598a7a12da5d183965d5c896815a0e
Signed-off-by: Philippe Coval <p.coval@samsung.com>