### PR TITLE
example: platform: Add play-phat board

### DIFF
--- a/example/platform/board/play-phat.js
+++ b/example/platform/board/play-phat.js
@@ -1,0 +1,76 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ *
+ * Copyright 2018-present Samsung Electronics France SAS, and other contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+const {
+  Thing,
+} = require('webthing');
+
+const GpioProperty = require('../gpio/gpio-property');
+
+class PlayPHatThing extends Thing {
+  constructor(name, type, description) {
+    super(name || 'PlayPHat',
+          type || [],
+          description || 'A web connected Play RaspberryPi Hat');
+    const _this = this;
+    this.gpioProperties = [
+      new GpioProperty(this, 'Left', false,
+                       {description:
+                        'SW1 Sensor Button on GPIO4 (Pin7)'},
+                       {direction: 'in', pin: 4}),
+      new GpioProperty(this, 'Right', false,
+                       {description:
+                        'SW2 Sensor button on GPIO17 (Pin11)'},
+                       {direction: 'in', pin: 17}),
+      new GpioProperty(this, 'Up', false,
+                       {description:
+                        'SW3 Sensor button on GPIO22 (Pin15)'},
+                       {direction: 'in', pin: 22}),
+      new GpioProperty(this, 'Down', false,
+                       {description:
+                        'SW4 Sensor button on GPIO27 (Pin13)'},
+                       {direction: 'in', pin: 27}),
+      new GpioProperty(this, 'A', false,
+                       {description:
+                        'SW5 Sensor button on GPIO19 (Pin35)'},
+                       {direction: 'in', pin: 19}),
+      new GpioProperty(this, 'B', false,
+                       {description:
+                        'SW6 Sensor button on GPIO26 (Pin37)'},
+                       {direction: 'in', pin: 26}),
+      new GpioProperty(this, 'Start', false,
+                       {description:
+                        'SW7 Sensor button on GPIO5 (Pin29)'},
+                       {direction: 'in', pin: 5}),
+      new GpioProperty(this, 'Select', false,
+                       {description:
+                        'SW8 Sensor button on GPIO6 (Pin31)'},
+                       {direction: 'in', pin: 6}),
+    ];
+    this.gpioProperties.forEach((property) => {
+      _this.addProperty(property);
+    });
+  }
+
+  close() {
+    this.gpioProperties.forEach((property) => {
+      property.close && property.close();
+    });
+  }
+}
+
+module.exports = function() {
+  if (!module.exports.instance) {
+    module.exports.instance = new PlayPHatThing();
+  }
+  return module.exports.instance;
+};


### PR DESCRIPTION
Note that gpio_key could overlap, see later makefile

For more insights check:

https://github.com/rzr/webthing-iotjs/wiki/Sensor

Change-Id: I0de4ace8a21a0592e5e09e692d43aa04ed7488e8
Origin: https://github.com/rzr/webthing-iotjs
Forwarded: https://github.com/mozilla-iot/webthing-node/pull/31
Thanks-to: @Leon-Anavi <leon@anavi.org>
Signed-off-by: Philippe Coval <p.coval@samsung.com>