### PR TITLE
example: platform: Add flex-phat board

### DIFF
--- a/example/platform/board/flex-phat.js
+++ b/example/platform/board/flex-phat.js
@@ -1,0 +1,68 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ *
+ * Copyright 2018-present Samsung Electronics France SAS, and other contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+const {
+  Thing,
+} = require('webthing');
+
+const GpioProperty = require('../gpio/gpio-property');
+
+class FlexPHatThing extends Thing {
+  constructor(name, type, description) {
+    super(name || 'FlexPHat',
+          type || [],
+          description || 'A web connected Flex RaspberryPi Hat');
+    const _this = this;
+    this.gpioProperties = [
+      new GpioProperty(this, 'Relay', false,
+                       {description:
+                             'Actuator (on GPIO5)'},
+                       {direction: 'out', pin: 5}),
+      new GpioProperty(this, 'BlueLED', false,
+                       {description:
+                             'Actuator (on GPIO13)'},
+                       {direction: 'out', pin: 13}),
+      new GpioProperty(this, 'GreenLED', false,
+                       {description:
+                             'Actuator (on GPIO19)'},
+                       {direction: 'out', pin: 19}),
+      new GpioProperty(this, 'RedLED', false,
+                       {description:
+                             'Actuator (on GPIO26)'},
+                       {direction: 'out', pin: 26}),
+      new GpioProperty(this, 'Button', false,
+                       {description:
+                             'Push Button (on GPIO11)'},
+                       {direction: 'in', pin: 11}),
+      new GpioProperty(this, 'GPIO23', false,
+                       {description:
+                             'Input on GPIO 23 (unwired but modable)'},
+                       {direction: 'in', pin: 23}),
+    ];
+    this.gpioProperties.forEach((property) => {
+      _this.addProperty(property);
+    });
+  }
+
+  close() {
+    this.gpioProperties.forEach((property) => {
+      property.close && property.close();
+    });
+  }
+}
+
+module.exports = function() {
+  if (!module.exports.instance) {
+    module.exports.instance = new FlexPHatThing();
+  }
+  return module.exports.instance;
+};


### PR DESCRIPTION
Usage:

    node example/platform flex-phat

For more insights check:

https://github.com/rzr/webthing-iotjs/wiki/Sensor

Thanks-to: @Leon-Anavi <leon@anavi.org>
Change-Id: I3612e28ae50d5bd14f5f4b06c5e0dbead7a84a92
Origin: https://github.com/rzr/webthing-iotjs
Forwarded: https://github.com/mozilla-iot/webthing-node/pull/31
Signed-off-by: Philippe Coval <p.coval@samsung.com>