### PR TITLE
example: platform: Add Makefile helper

### DIFF
--- a/example/platform/Makefile
+++ b/example/platform/Makefile
@@ -1,0 +1,73 @@
+#!/bin/make -f
+# -*- makefile -*-
+# SPDX-License-Identifier: MPL-2.0
+#{
+# Copyright 2018-present Samsung Electronics France SAS, and other contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+#}
+
+main_src ?= index.js
+lib_srcs ?= $(wildcard */*.js | sort)
+runtime ?= node
+topreldir ?= ../..
+topdir ?= ${CURDIR}/${topreldir}
+run_args ?= start
+sudo ?= sudo
+
+default: check
+
+%: %/${runtime}
+	echo "# $@: $^"
+
+run/%: ${main_src} /sys/class/gpio/export
+	ls $<
+	${@F} $< ${run_args}
+
+run/node: ${main_src} package.json /sys/class/gpio/export
+	ls -l node_modules || ${MAKE} node_modules
+	ls -l ${topreldir}/node_modules || { cd ${topreldir} && npm install ; }
+	npm run ${run_args}
+
+run: run/${runtime}
+
+force:
+
+/sys/class/gpio/export: force
+	${sudo} cat /sys/kernel/debug/gpio
+
+node_modules: package.json
+	-which npm
+	npm --version
+	npm install
+	@mkdir -p "$@"
+
+package.json:
+	npm init
+
+check/%: ${lib_srcs}
+	status=0 ; \
+	for src in $^; do \
+ echo "log: check: $${src}: ($@)" ; \
+ ${@F} $${src} \
+ && echo "log: check: $${src}: OK" \
+ || status=1 ; \
+ done ; \
+	exit $${status}
+
+check: check/${runtime}
+
+
+flex-phat/%: ${main_src} /sys/class/gpio/export
+	-gpio -v || sudo apt-get install gpio
+	gpio -g mode 11 up
+	${MAKE} run/${@F} run_args="${@D}"
+
+
+play-phat/%: ${main_src} /sys/class/gpio/export
+	-lsmod | grep gpio_keys \
+ && ${sudo} modprobe -rv gpio_keys \
+ || echo "log: will use /sys/class/gpio/"
+	${MAKE} run/${@F} run_args="${@D}"


### PR DESCRIPTION
To setup GPIOs, it will be used also for IoT.js

Usage:
```
make -C example/platform/ flex-phat

log: board: flex-phat: Loading
Usage:
/home/pi/.nvm/versions/node/v8.11.3/bin/node /tmp/pi/mnt/local/local/home/philippe/var/cache/url/git/ssh/github.com/tizenteam/webthing-node/src/webthing-node/example/platform/index [board] [port]
Try:
curl -H "Accept: application/json" http://localhost:8888

log: board: flex-phat: Started
log: GPIO: GreenLED: open:
log: GPIO: BlueLED: open:
log: GPIO: Relay: open:
log: GPIO: RedLED: open:
log: GPIO: Button: open:
log: GPIO: GPIO23: open:
log: GPIO: Button: change: false
log: GPIO: Button: change: true
log: GPIO: RedLED: writing: true
log: GPIO: GreenLED: writing: true
log: GPIO: Relay: close:
log: GPIO: BlueLED: close:
log: GPIO: GreenLED: close:
log: GPIO: RedLED: close:
log: GPIO: Button: close:
log: GPIO: GPIO23: close:
log: board: flex-phat: Stopped
```

Cc: @Leon-Anavi <leon@anavi.org>
Change-Id: Idea8e081c9e1f4d880d937cd0537cf31215f48b5
Origin: https://github.com/rzr/webthing-iotjs
Forwarded: https://github.com/mozilla-iot/webthing-node/pull/31
Signed-off-by: Philippe Coval <p.coval@samsung.com>