### PR TITLE
adc: Add Adc class

### DIFF
--- a/example/platform/adc/adc-property.js
+++ b/example/platform/adc/adc-property.js
@@ -1,0 +1,85 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ *
+ * Copyright 2018-present Samsung Electronics France SAS, and other contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+const console = require('console');
+
+// Disable logs here by editing to '!console.log'
+const log = console.log || function() {};
+
+const {
+  Property,
+  Value,
+} = require('webthing');
+
+const adc = require('../adc');
+
+class AdcInProperty extends Property {
+  constructor(thing, name, value, metadata, config) {
+    const valueObject = new Value(Number(value), () => {
+    });
+    super(thing, name, valueObject,
+          {
+            '@type': 'LevelProperty',
+            label: (metadata && metadata.label) || `Level: ${name}`,
+            type: 'number',
+            readOnly: true,
+            description:
+            (metadata && metadata.description) ||
+              (`ADC Sensor on pin=${config.pin}`),
+          });
+    const self = this;
+    this.valueObject = valueObject;
+    config.frequency = config.frequency || 1;
+    config.range = config.range || 4096;
+    this.period = 1000.0 / config.frequency;
+    this.config = config;
+    this.port = adc.open(config, function(err) {
+      log(`log: ADC: ${self.getName()}: open: ${err} (null expected)`);
+      if (err) {
+        console.error(`errror: ADC: ${self.getName()}: Fail to open:\
+ ${config.pin}`);
+        return null;
+      }
+      self.inverval = setInterval(() => {
+        let value = self.port.readSync();
+        log(`log: ADC:\
+ ${self.getName()}: update: 0x${Number(value).toString(0xF)}`);
+        value = Number(Math.floor(100.0 * value / self.config.range));
+        if (value !== self.lastValue) {
+          log(`log: ADC: ${self.getName()}: change: ${value}%`);
+          self.valueObject.notifyOfExternalUpdate(value);
+          self.lastValue = value;
+        }
+      }, self.period);
+    });
+  }
+
+  close() {
+    try {
+      this.inverval && clearInterval(this.inverval);
+      this.port && this.port.closeSync();
+    } catch (err) {
+      console.error(`error: ADC: ${this.getName()} close:${err}`);
+      return err;
+    }
+    log(`log: ADC: ${self.getName()}: close:`);
+  }
+}
+
+function AdcProperty(thing, name, value, metadata, config) {
+  if (config.direction === 'in') {
+    return new AdcInProperty(thing, name, value, metadata, config);
+  }
+  throw 'error: Invalid param';
+}
+
+module.exports = AdcProperty;

--- a/example/platform/adc/index.js
+++ b/example/platform/adc/index.js
@@ -1,0 +1,28 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: ISC
+/**
+ * Copyright 2018-present Samsung Electronics France SAS, and other contributors
+ *
+ * This Source Code Form is subject to the terms of the ICS Licence:
+ * https://spdx.org/licenses/ISC.html#licenseText
+ */
+
+const fs = require('fs');
+
+function Adc() {
+  this.open = function(config, callback) {
+    this.config = config;
+    fs.access(config.device, fs.R_OK, callback);
+    return this;
+  };
+
+  this.readSync = function() {
+    const contents = fs.readFileSync(this.config.device, 'ascii');
+    return contents;
+  };
+
+  this.closeSync = function() {
+  };
+}
+
+module.exports = new Adc();

--- a/example/platform/board/artik530.js
+++ b/example/platform/board/artik530.js
@@ -14,6 +14,7 @@ const {
   Thing,
 } = require('webthing');
 
+const AdcProperty = require('../adc/adc-property');
 const GpioProperty = require('../gpio/gpio-property');
 
 class ARTIK530Thing extends Thing {
@@ -22,7 +23,7 @@ class ARTIK530Thing extends Thing {
           type || [],
           description || 'A web connected ARTIK530 or ARTIK720');
     const _this = this;
-    this.gpioProperties = [
+    this.pinProperties = [
       new GpioProperty(this, 'RedLED', false,
                        {description:
                              'Red LED on interposer board (on GPIO28)'},
@@ -40,14 +41,24 @@ class ARTIK530Thing extends Thing {
                        {description:
                              'SW404 Button: Next to blue LED (on GPIO32)'},
                        {direction: 'in', pin: 32}),
+      new AdcProperty(this, 'ADC0', 0,
+                      {description: 'Analog port of ARTIK05x'},
+                      {direction: 'in',
+                       device: '/sys/bus/platform/devices\
+/c0053000.adc/iio:device0/in_voltage0_raw'}),
+      new AdcProperty(this, 'ADC1', 0,
+                      {description: 'Analog port of ARTIK05x'},
+                      {direction: 'in',
+                       device: '/sys/bus/platform/devices/\
+c0053000.adc/iio:device0/in_voltage1_raw'}),
     ];
-    this.gpioProperties.forEach((property) => {
+    this.pinProperties.forEach((property) => {
       _this.addProperty(property);
     });
   }
 
   close() {
-    this.gpioProperties.forEach((property) => {
+    this.pinProperties.forEach((property) => {
       property.close && property.close();
     });
   }


### PR DESCRIPTION
To abstract different ADC or sysfs API,

Note: later this class could land later in separate project
(ie: gpio, iotjs-node? sysfs-node?)
but since it's trivial let's share it here.

Relate-to: https://github.com/EnotionZ/gpio/pull/53
Change-Id: I923159901d3af3e1990ccf3e1510d561c2e0783b
Signed-off-by: Philippe Coval <p.coval@samsung.com>