### PR TITLE
example: build: Prepare Pi for traffic-phat

### DIFF
--- a/example/platform/Makefile
+++ b/example/platform/Makefile
@@ -71,3 +71,13 @@ play-phat/%: ${main_src} /sys/class/gpio/export
  && ${sudo} modprobe -rv gpio_keys \
  || echo "log: will use /sys/class/gpio/"
 	${MAKE} run/${@F} run_args="${@D}"
+
+traffic-phat/%: ${main_src} /sys/class/gpio/export
+	-gpio -v || sudo apt-get install gpio || echo "TODO: install BCM tool"
+	list="13 19 26" ; \
+ for num in $${list} ; do \
+ sudo gpio export $num in \
+ sudo gpio -g mode $num up \
+ sudo gpio unexport $num \
+ done
+	${MAKE} run/${@F} run_args="${@D}"


### PR DESCRIPTION
A way to use generic npm's gpio until supporting wiringpi module

Relate-to: https://github.com/TizenTeam/webthing-iotjs/wiki/Sensors
Change-Id: I2604a16448439b52c6b68ea3639537730320ff9a
Signed-off-by: Philippe Coval <p.coval@samsung.com>