### PR TITLE
platform: gpio: Cast to boolean if type mismatch

### DIFF
--- a/example/platform/gpio/gpio-property.js
+++ b/example/platform/gpio/gpio-property.js
@@ -24,7 +24,7 @@ const gpio = require('gpio');
 
 class GpioOutProperty extends Property {
   constructor(thing, name, value, metadata, config) {
-    super(thing, name, new Value(value),
+    super(thing, name, new Value(Boolean(value)),
           {
             '@type': 'OnOffProperty',
             label: (metadata && metadata.label) || `On/Off: ${name}`,


### PR DESCRIPTION
Really small improvement,
but since some gpio libs are using numbers (0/1)
it's safer this way.

Change-Id: Ib663e95e5dfaffb06853165cccc8e82f9c1e9dc7
Signed-off-by: Philippe Coval <p.coval@samsung.com>