### PR TITLE
npm: Freeze deps before version update

### DIFF
--- a/example/platform/package-lock.json
+++ b/example/platform/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "gpio": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/gpio/-/gpio-0.2.9.tgz",
-      "integrity": "sha512-tcMh77effIK9RjJEWdDDOpQZ3MqEDxGTpnrnaoHhHPRI1LzNECNYg7KmptvedIci3Drop27dUD8injoH/oKZ5w=="
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/gpio/-/gpio-0.2.10.tgz",
+      "integrity": "sha512-VBFvAye/pK/oWHDUCa2F8jyrtHhnHXR/zHxMz3REEgznfMCQyzy6yRU8hFNuMSO+AG3YN4fH71Suj6mvM3cG3w=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webthing",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This should have been done earlier,
but let's do it now before bumping to 0.8.2 or 0.9.0 ?

Then webthing-iotjs will be released on it.

Change-Id: Ic956ae7d9743d9e7e2d29192d59441d2cf75a3f2
Origin: https://github.com/TizenTeam/webthing-node
Signed-off-by: Philippe Coval <p.coval@samsung.com>