### PR TITLE
Use case insensitive verification for host name

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -607,7 +607,7 @@ class WebThingServer {
     this.port = Number(port) || (sslOptions ? 443 : 80);
     this.hostname = hostname;
 
-    const systemHostname = os.hostname();
+    const systemHostname = os.hostname().toLowerCase();
     this.hosts = [
       '127.0.0.1',
       `127.0.0.1:${port}`,
@@ -618,6 +618,7 @@ class WebThingServer {
     ];
 
     if (hostname) {
+      hostname = hostname.toLowerCase();
       this.hosts.push(hostname, `${hostname}:${port}`);
     }
 
@@ -650,7 +651,7 @@ class WebThingServer {
     // Validate Host header
     this.app.use((request, response, next) => {
       const host = request.headers.host;
-      if (this.hosts.includes(host)) {
+      if (this.hosts.includes(host.toLowerCase())) {
         next();
       } else {
         response.status(403).send('Forbidden');


### PR DESCRIPTION
Host names are case insensitive, so store and compare them in lower case.