### PR TITLE
Add index.js as fallback to npm's main

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./webthing.js');


### PR DESCRIPTION
This will help iotjs or configurations ignoring package.json's main field.

The source can be cloned and used from runtime's PATH.

Change-Id: I7cfcc0494650be8e41619f9d527ab712a58ef15d
Signed-off-by: Philippe Coval <p.coval@samsung.com>