### PR TITLE
docker: Export sysfs for gpio and use host mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     build: .
     command: start
     volumes:
-      - /usr/local/webthing-node/webthing-node
+      - /sys:/sys
     ports:
       - "8888:8888"
+    network_mode: "host"


### PR DESCRIPTION
Other folder may not be shared,

It has been tested on ARTIK710

Change-Id: Ia97d2aefef1dee4746e85e4fdbe0d72db8fbda4f
Signed-off-by: Philippe Coval <p.coval@samsung.com>