### PR TITLE
docker: Align license to upstream project (MPL-2.0)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,11 @@
 # -*- coding: utf-8 -*-
-# SPDX-License-Identifier: MPL-2.0 
+# SPDX-License-Identifier: MPL-2.0
 #{
-#  Copyright: 2018-present Samsung Electronics Co., Ltd. and other contributors
-# 
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-# 
-#      http://www.apache.org/licenses/LICENSE-2.0
-# 
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Copyright: 2018-present Samsung Electronics France SAS, and other contributors
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/ .
 #}
 
 version: "2"


### PR DESCRIPTION
I was upstream of this file, so it's fine.

Change-Id: I4d72b4c3a9b8246965c8b1bf7d628308ab6ba48c
Signed-off-by: Philippe Coval <p.coval@samsung.com>