### PR TITLE
platform: Add Edison board to test PWM

### DIFF
--- a/example/platform/board/edison.js
+++ b/example/platform/board/edison.js
@@ -1,0 +1,48 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ *
+ * Copyright 2018-present Samsung Electronics France SAS, and other contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+const {
+  Thing,
+} = require('webthing');
+
+const PwmProperty = require('../pwm/pwm-property');
+
+class EdisonThing extends Thing {
+  constructor(name, type, description) {
+    super('urn:dev:ops:my-edison-1234',
+          name || 'Edison',
+          type || [],
+          description || 'A web connected Edison');
+    const self = this;
+    this.pinProperties = [
+      new PwmProperty(this, 'PWM0', 50, {
+        description: 'Analog port of Edison',
+      }),
+    ];
+    this.pinProperties.forEach((property) => {
+      self.addProperty(property);
+    });
+  }
+
+  close() {
+    this.pinProperties.forEach((property) => {
+      property.close && property.close();
+    });
+  }
+}
+
+module.exports = function() {
+  if (!module.exports.instance) {
+    module.exports.instance = new EdisonThing();
+  }
+  return module.exports.instance;
+};


### PR DESCRIPTION
It was tested on Intel edison on PWM0
GPIO12 must be manually configured first
using:

```sh
gpio=12
echo $gpio | sudo tee -a /sys/class/gpio/export
echo out | sudo tee /sys/class/gpio/gpio$gpio/direction
echo mode1 | sudo tee /sys/kernel/debug/gpio_debug/gpio${gpio}/current_pinmux
```

More insights at:

https://github.com/rzr/webthing-iotjs/wiki/Actuator

Relate-to: https://github.com/rzr/webthing-iotjs/issues/3
Change-Id: I6f587a840e8c429d91ba2491e7cddfdfab66bf4b
Signed-off-by: Philippe Coval <p.coval@samsung.com>