### PR TITLE
plaform: Refactor ADC module as class

### DIFF
--- a/example/platform/adc/index.js
+++ b/example/platform/adc/index.js
@@ -9,20 +9,23 @@
 
 const fs = require('fs');
 
-function Adc() {
-  this.open = function(config, callback) {
+class Adc {
+  constructor(config, callback) {
     this.config = config;
     fs.access(config.device, fs.R_OK, callback);
-    return this;
-  };
+  }
 
-  this.readSync = function() {
+  readSync() {
     const contents = fs.readFileSync(this.config.device, 'ascii');
     return contents;
-  };
+  }
 
-  this.closeSync = function() {
-  };
+  closeSync() {
+  }
+
 }
 
-module.exports = new Adc();
+
+module.exports.open = function(config, callback) {
+  return new Adc(config, callback);
+};


### PR DESCRIPTION
There was a bug when using multiple instances.
It was tested on ARTIK1020

Relate-to: https://github.com/mozilla-iot/webthing-node/pull/49
Change-Id: Idbb9d0f53fc1534407657c9b63a29db50297ae88
Signed-off-by: Philippe Coval <p.coval@samsung.com>