### PR TITLE
platform: Add PWM support to artik1020

### DIFF
--- a/example/platform/board/artik1020.js
+++ b/example/platform/board/artik1020.js
@@ -15,6 +15,7 @@ const {
 } = require('webthing');
 
 const AdcProperty = require('../adc/adc-property');
+const PwmProperty = require('../pwm/pwm-property');
 
 
 class ARTIK1020Thing extends Thing {
@@ -26,35 +27,41 @@ class ARTIK1020Thing extends Thing {
     const self = this;
     this.pinProperties = [
       new AdcProperty(this, 'ADC0', 0,
-                      {description: 'Analog port of ARTIK1020'},
+                      {description: 'A0 on J24 of board'},
                       {direction: 'in',
                        device: '/sys/devices/12d10000.adc/iio:device0\
 /in_voltage0_raw'}),
       new AdcProperty(this, 'ADC1', 0,
-                      {description: 'Analog port of ARTIK1020'},
+                      {description: 'A1 on J24 of board'},
                       {direction: 'in',
                        device: '/sys/devices/12d10000.adc/iio:device0\
 /in_voltage1_raw'}),
       new AdcProperty(this, 'ADC2', 0,
-                      {description: 'Analog port of ARTIK1020'},
+                      {description: 'A2 on J24 of board'},
                       {direction: 'in',
                        device: '/sys/devices/12d10000.adc/iio:device0\
 /in_voltage2_raw'}),
       new AdcProperty(this, 'ADC3', 0,
-                      {description: 'Analog port of ARTIK1020'},
+                      {description: 'A3 on J24 of board'},
                       {direction: 'in',
                        device: '/sys/devices/12d10000.adc/iio:device0\
 /in_voltage5_raw'}),
       new AdcProperty(this, 'ADC4', 0,
-                      {description: 'Analog port of ARTIK1020'},
+                      {description: 'A4 on J24 of board'},
                       {direction: 'in',
                        device: '/sys/devices/12d10000.adc/iio:device0\
 /in_voltage6_raw'}),
       new AdcProperty(this, 'ADC5', 0,
-                      {description: 'Analog port of ARTIK1020'},
+                      {description: 'A5 on J24 of board'},
                       {direction: 'in',
                        device: '/sys/devices/12d10000.adc/iio:device0\
 /in_voltage7_raw'}),
+      new PwmProperty(this, 'PWM0', 50,
+                      {description: 'XPWMO1 on J26[6] of board (pwm0)'}),
+
+      new PwmProperty(this, 'PWM1', 50,
+                      {description: 'XPWMO0 on J26[5] of board (pwm1)'},
+                      {pwm: {pin: 1}}),
     ];
     this.pinProperties.forEach((property) => {
       self.addProperty(property);


### PR DESCRIPTION
Note that accessing PWM is requiering write access to sysfs

Add also mapping info.

Relate-to: https://developer.artik.io/documentation/developer-guide/gpio/gpio-mapping.html
Change-Id: Ib6d4592d96a0d0fbe089b6d4b09ec216f2215ce6
Signed-off-by: Philippe Coval <p.coval@samsung.com>