### PR TITLE
example: Rename brightness property to level

### DIFF
--- a/example/single-thing.js
+++ b/example/single-thing.js
@@ -23,7 +23,7 @@ class FadeAction extends Action {
   performAction() {
     return new Promise((resolve) => {
       setTimeout(() => {
-        this.thing.setProperty('brightness', this.input.brightness);
+        this.thing.setProperty('level', this.input.level);
         this.thing.addEvent(new OverheatedEvent(this.thing, 102));
         resolve();
       }, this.input.duration);
@@ -49,7 +49,7 @@ function makeThing() {
                  }));
   thing.addProperty(
     new Property(thing,
-                 'brightness',
+                 'level',
                  new Value(50),
                  {
                    '@type': 'BrightnessProperty',
@@ -69,11 +69,11 @@ function makeThing() {
       input: {
         type: 'object',
         required: [
-          'brightness',
+          'level',
           'duration',
         ],
         properties: {
-          brightness: {
+          level: {
             type: 'integer',
             minimum: 0,
             maximum: 100,


### PR DESCRIPTION
Align properties to  Virtual Dimmable Light
from VirtualThings adapter (same as arduino too)

This change was motivated by aframe-webthing project
that could use either this example or gateway.

Relate-to: https://github.com/rzr/aframe-webthing/commit/60ea9f8a63cb38218f180f8035c09510f740db21
Change-Id: I22197c6b78c7e6f56f9485c4c028aa62a16d12f9
Signed-off-by: Philippe Coval <p.coval@samsung.com>