### PR TITLE
platform: Start app only if main script

### DIFF
--- a/example/platform/index.js
+++ b/example/platform/index.js
@@ -51,5 +51,6 @@ Try:\ncurl -H "Accept: application/json" ${url}\
   log(`log: board: ${board}: Started`);
 }
 
-runServer();
-
+if (module.parent === null) {
+  runServer();
+}


### PR DESCRIPTION
This can be helpful for IoT.js
that would use a launcher script that
include script and run it later.

Change-Id: I8e5076f84a206b8e28ee0139b88a1dd6c844ee8a
Signed-off-by: Philippe Coval <p.coval@samsung.com>