### PR TITLE
example: Add licence mini-header

### DIFF
--- a/example/multiple-things.js
+++ b/example/multiple-things.js
@@ -1,3 +1,6 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: MPL-2.0
+
 const {
   Action,
   Event,

--- a/example/single-thing.js
+++ b/example/single-thing.js
@@ -1,3 +1,6 @@
+// -*- mode: js; js-indent-level:2;  -*-
+// SPDX-License-Identifier: MPL-2.0
+
 const {
   Action,
   Event,


### PR DESCRIPTION
Along editor hints.

The reason of doing this, is because aframe-webthing (MPL-2.0)
is seding thoses files to use level instead of brighness.

Change-Id: I681a95037941c7aa13596d8080b3d544166b39ab
Signed-off-by: Philippe Coval <p.coval@samsung.com>