### PR TITLE
tools: Fix typo in license of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+# file, You can obtain one at http://mozilla.org/MPL/2.0/ .
 #}
 
 FROM node:8-stretch


### PR DESCRIPTION
Change-Id: If076582241f03be398ae1fbd7524a9aecaffa3c1
Signed-off-by: Philippe Coval <p.coval@samsung.com>